### PR TITLE
Timeout fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -222,7 +222,7 @@ func main() {
 	http.Handle(*metricsPath+"/", sh)
 	http.Handle(*metricsPath, promhttp.Handler())
 
-	srv := &http.Server{Addr: *listenAddress, ReadTimeout: 5 * time.Second, WriteTimeout: 5 * time.Second}
+	srv := &http.Server{Addr: *listenAddress, ReadTimeout: 5 * time.Second, WriteTimeout: *timeout}
 	if err := srv.ListenAndServe(); err != nil {
 		log.Fatalf("Unable to setup HTTP server: %v", err)
 	}


### PR DESCRIPTION
HTTP write timeout should match script run timeout. The default script run timeout is 1 minute, but it is effectively 5 seconds (the HTTP write timeout).